### PR TITLE
Update bower.json with empty ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-bootstrap-affix",
   "version": "0.2.1",
+  "ignore": [],
   "dependencies": {
     "angular-jquery": "~0.2.1"
   },


### PR DESCRIPTION
avoid 'invalid-meta angular-bootstrap-affix is missing "ignore" entry in bower.json' when installing via bower. As suggested here: https://github.com/bower/bower/issues/1388
