### PR TITLE
Remove unused parameters to reduce dependencies

### DIFF
--- a/src/bootstrap-affix.js
+++ b/src/bootstrap-affix.js
@@ -2,7 +2,7 @@
 
 angular.module('mgcrea.bootstrap.affix', ['mgcrea.jquery'])
 
-  .directive('bsAffix', function($window, $location, $routeParams, dimensions) {
+  .directive('bsAffix', function($window, dimensions) {
 
     var checkPosition = function(instance, el, options) {
 


### PR DESCRIPTION
Remove unused parameters to reduce dependencies.

routeParams was unused and breaks in ui-router projects.
